### PR TITLE
Fix typo on support page

### DIFF
--- a/pages/support.vue
+++ b/pages/support.vue
@@ -25,9 +25,7 @@
             </a>
           </p>
           <p>
-            <a
-              :href="issues"
-              class="button is-info">
+            <a :href="issues">
               See all support requests
             </a>
           </p>


### PR DESCRIPTION
First commit fixes a typo ("all request" -> "all requests") on the support page.

Second commit changes the "See all support requests" to be a link instead of a button. I think using a button for that is a bit confusing, but I can remove the commit if you don't agree.