### PR TITLE
chore(k8s): add startup probe

### DIFF
--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -29,14 +29,21 @@ spec:
             cpu: "600m"
 
         readinessProbe:
-          initialDelaySeconds: 30
           timeoutSeconds: 5
           httpGet:
             port: http
             path: /api/health
 
         livenessProbe:
-          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          httpGet:
+            port: http
+            path: /api/health
+
+        startupProbe:
+          # Give the app about 5min to start
+          periodSeconds: 10
+          failureThreshold: 30
           timeoutSeconds: 5
           httpGet:
             port: http


### PR DESCRIPTION
This adds a startup probe, which runs on application startup only and avoids restart loops if the app takes too much time to start