### PR TITLE
Run docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,10 @@ RUN bash /app/build.sh
 FROM node:12-alpine
 RUN npm install -g npm@6.13.7
 
-USER node
 WORKDIR /app
+RUN mkdir /app/nuxt_original
+RUN chown -R node:node /app && chgrp -R 0 /app && chmod -R g+rwX /app
+USER node
 
 COPY package.json package-lock.json ./
 RUN npm ci --production --no-optional


### PR DESCRIPTION
By default, Docker runs commands inside the container as root which violates the Principle of Least Privilege (PoLP) when superuser permissions are not strictly required. You want to run the container as an unprivileged user whenever possible. The node images provide the node user for such purpose.

See https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user